### PR TITLE
fix: skip fakeIP for ICMP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,10 +47,12 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/lixiangzhong/dnsutil v1.4.0 // indirect
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/miekg/dns v1.1.43 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/lixiangzhong/dnsutil v1.4.0 h1:S75ND4O8IbNhVdaP/Bn+3YHXPYvt6jpeqy3Yyr+iUNY=
+github.com/lixiangzhong/dnsutil v1.4.0/go.mod h1:hQj5Vdv9+/m5GZxu75Hp4SMPeYV3JZUABlUadwNVFmk=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
@@ -294,6 +296,10 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
+github.com/miekg/dns v1.1.40 h1:pyyPFfGMnciYUk/mXpKkVmeMQjfXqt3FAJ2hy7tPiLA=
+github.com/miekg/dns v1.1.40/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
+github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -582,6 +588,7 @@ golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -637,6 +644,7 @@ golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/proxy/real_ip_mapper.go
+++ b/proxy/real_ip_mapper.go
@@ -1,0 +1,30 @@
+package proxy
+
+import (
+	"inet.af/netaddr"
+	"sync"
+)
+
+type RealIPMapper struct {
+	mapper map[netaddr.IP]netaddr.IP
+	mutex  sync.Mutex
+}
+
+func NewRealIPMapper() *RealIPMapper {
+	return &RealIPMapper{
+		mapper: make(map[netaddr.IP]netaddr.IP),
+	}
+}
+
+func (m *RealIPMapper) Set(fakeIP netaddr.IP, realIP netaddr.IP) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.mapper[fakeIP] = realIP
+}
+
+func (m *RealIPMapper) Get(fakeIP netaddr.IP) (realIP netaddr.IP, ok bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	realIP, ok = m.mapper[fakeIP]
+	return
+}

--- a/tracer/stop_handler.go
+++ b/tracer/stop_handler.go
@@ -47,9 +47,11 @@ func (t *Tracer) exitHandler(pid int, regs *syscall.PtraceRegs) (err error) {
 			Family: int(args[0]),
 			// FIXME: This field may be not so exact. To reproduce: curl -v example.com
 			// 		So the compromise is that TCP and UDP ports to listen at must be the same.
-			Type: int(args[1]),
+			Type:     int(args[1]),
+			Protocol: int(args[2]),
 		}
 		t.saveSocketInfo(pid, fd, socketInfo)
+		t.log.Traceln(fd, socketInfo)
 		t.log.Tracef("new socket (%v): pid: %v, fd %v", t.network(&socketInfo), pid, fd)
 	case syscall.SYS_FCNTL:
 		//t.log.Tracef("exitHandler: FCNTL: %v, inst: %v", pid, inst)
@@ -75,7 +77,6 @@ func (t *Tracer) exitHandler(pid int, regs *syscall.PtraceRegs) (err error) {
 			logrus.Tracef("socket error: pid: %v, errno: %v", pid, errno)
 			return nil
 		}
-		t.saveSocketInfo(pid, newFD, *socketInfo)
 		t.log.Tracef("SYS_FCNTL: copy %v -> %v", fd, newFD)
 	case syscall.SYS_CLOSE:
 		//t.log.Tracef("exitHandler: CLOSE: %v, inst: %v", pid, inst)
@@ -252,25 +253,26 @@ func (t *Tracer) checkSocket(pid int, fd uint64) (socketInfo *SocketMetadata, ex
 		return nil, false
 	}
 	switch socketInfo.Family {
-	case syscall.AF_INET, syscall.AF_INET6:
-		// support only ipv4, and ipv6
-	default:
-		return nil, false
-	}
-	switch {
-	// support only tcp, and udp
-	case socketInfo.Type&syscall.SOCK_STREAM == syscall.SOCK_STREAM:
-	case socketInfo.Type&syscall.SOCK_DGRAM == syscall.SOCK_DGRAM:
+	case syscall.AF_INET:
+	// support only ipv4, and ipv6
+	case syscall.AF_INET6:
+		// only filter tcp and udp traffic for ipv6
+		switch t.network(socketInfo) {
+		case "tcp", "udp":
+		default:
+			// no need to transform the fake IP to real IP
+			return nil, false
+		}
 	default:
 		return nil, false
 	}
 	return socketInfo, true
 }
 func (t *Tracer) portHackTo(socketInfo *SocketMetadata) int {
-	switch {
-	case socketInfo.Type&syscall.SOCK_STREAM == syscall.SOCK_STREAM:
+	switch t.network(socketInfo) {
+	case "tcp":
 		return t.proxy.TCPPort()
-	case socketInfo.Type&syscall.SOCK_DGRAM == syscall.SOCK_DGRAM:
+	case "udp":
 		return t.proxy.UDPPort()
 	default:
 		return 0
@@ -278,14 +280,29 @@ func (t *Tracer) portHackTo(socketInfo *SocketMetadata) int {
 }
 
 func (t *Tracer) network(socketInfo *SocketMetadata) string {
-	switch {
-	case socketInfo.Type&syscall.SOCK_STREAM == syscall.SOCK_STREAM:
-		return "tcp"
-	case socketInfo.Type&syscall.SOCK_DGRAM == syscall.SOCK_DGRAM:
-		return "udp"
-	default:
+	if socketInfo.Family != syscall.AF_INET && socketInfo.Family != syscall.AF_INET6 {
 		return ""
 	}
+	switch {
+	case socketInfo.Type&syscall.SOCK_STREAM == syscall.SOCK_STREAM:
+		switch socketInfo.Protocol {
+		case 0, syscall.IPPROTO_TCP:
+			return "tcp"
+		}
+	case socketInfo.Type&syscall.SOCK_DGRAM == syscall.SOCK_DGRAM:
+		switch socketInfo.Protocol {
+		case 0, syscall.IPPROTO_UDP, syscall.IPPROTO_UDPLITE:
+			return "udp"
+		}
+	case socketInfo.Type&syscall.SOCK_RAW == syscall.SOCK_RAW:
+		switch socketInfo.Protocol {
+		case syscall.IPPROTO_TCP:
+			return "tcp"
+		case syscall.IPPROTO_UDP, syscall.IPPROTO_UDPLITE:
+			return "udp"
+		}
+	}
+	return ""
 }
 
 func (t *Tracer) handleINet4(socketInfo *SocketMetadata, bSockAddr []byte) (sockAddrToPock []byte, err error) {
@@ -298,7 +315,8 @@ func (t *Tracer) handleINet4(socketInfo *SocketMetadata, bSockAddr []byte) (sock
 		// but only keep DNS packets sent to the port 53
 		return nil, nil
 	}
-	if ip := netaddr.IPFrom4(addr.Addr); ip.IsLoopback() && !(network == "udp" && targetPort == 53) {
+	isDNS := network == "udp" && targetPort == 53
+	if ip := netaddr.IPFrom4(addr.Addr); (network == "tcp" || network == "udp") && ip.IsLoopback() && !isDNS {
 		// skip loopback
 		// but only keep DNS packets sent to the port 53
 		t.log.Tracef("skip loopback: %v", netaddr.IPPortFrom(ip, binary.BigEndian.Uint16(addr.Port[:])).String())
@@ -306,19 +324,32 @@ func (t *Tracer) handleINet4(socketInfo *SocketMetadata, bSockAddr []byte) (sock
 	}
 	//logrus.Traceln("before", bSockAddr)
 	var originAddr string
-	if ip := netaddr.IPFrom4(addr.Addr); proxy.ReservedPrefix.Contains(ip) {
-		originAddr = net.JoinHostPort(
-			t.proxy.GetProjection(ip), // get original domain
-			strconv.Itoa(int(binary.BigEndian.Uint16(addr.Port[:]))),
-		)
-	} else {
+	ip := netaddr.IPFrom4(addr.Addr)
+	if network == "tcp" || network == "udp" {
+		if proxy.ReservedPrefix.Contains(ip) {
+			originAddr = net.JoinHostPort(
+				t.proxy.GetProjection(ip), // get original domain
+				strconv.Itoa(int(binary.BigEndian.Uint16(addr.Port[:]))),
+			)
+		} else {
+			originAddr = net.JoinHostPort(
+				netaddr.IPFrom4(addr.Addr).String(),
+				strconv.Itoa(int(binary.BigEndian.Uint16(addr.Port[:]))),
+			)
+		}
+		loopback := t.proxy.AllocProjection(originAddr)
+		addr.Addr = loopback.As4()
+	} else if proxy.ReservedPrefix.Contains(ip) {
 		originAddr = net.JoinHostPort(
 			netaddr.IPFrom4(addr.Addr).String(),
 			strconv.Itoa(int(binary.BigEndian.Uint16(addr.Port[:]))),
 		)
+
+		if realIp, ok := t.proxy.GetRealIP(ip); ok {
+			addr.Addr = realIp.As4()
+		}
 	}
-	loopback := t.proxy.AllocProjection(originAddr)
-	addr.Addr = loopback.As4()
+
 	binary.BigEndian.PutUint16(addr.Port[:], uint16(portHackTo))
 	//logrus.Traceln("port", addr.Port)
 	_bSockAddrToPock := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
@@ -328,7 +359,7 @@ func (t *Tracer) handleINet4(socketInfo *SocketMetadata, bSockAddr []byte) (sock
 	}))
 	bSockAddrToPock := make([]byte, len(_bSockAddrToPock))
 	copy(bSockAddrToPock, _bSockAddrToPock)
-	t.log.Tracef("handleINet4 (%v): origin: %v, after: %v", network, originAddr, net.JoinHostPort(loopback.String(), strconv.Itoa(portHackTo)))
+	t.log.Tracef("handleINet4 (%v): origin: %v, after: %v", network, originAddr, net.JoinHostPort(netaddr.IPFrom4(addr.Addr).String(), strconv.Itoa(portHackTo)))
 	return bSockAddrToPock, nil
 }
 

--- a/tracer/stop_handler.go
+++ b/tracer/stop_handler.go
@@ -51,7 +51,6 @@ func (t *Tracer) exitHandler(pid int, regs *syscall.PtraceRegs) (err error) {
 			Protocol: int(args[2]),
 		}
 		t.saveSocketInfo(pid, fd, socketInfo)
-		t.log.Traceln(fd, socketInfo)
 		t.log.Tracef("new socket (%v): pid: %v, fd %v", t.network(&socketInfo), pid, fd)
 	case syscall.SYS_FCNTL:
 		//t.log.Tracef("exitHandler: FCNTL: %v, inst: %v", pid, inst)
@@ -77,6 +76,7 @@ func (t *Tracer) exitHandler(pid int, regs *syscall.PtraceRegs) (err error) {
 			logrus.Tracef("socket error: pid: %v, errno: %v", pid, errno)
 			return nil
 		}
+		t.saveSocketInfo(pid, newFD, *socketInfo)
 		t.log.Tracef("SYS_FCNTL: copy %v -> %v", fd, newFD)
 	case syscall.SYS_CLOSE:
 		//t.log.Tracef("exitHandler: CLOSE: %v, inst: %v", pid, inst)

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -15,6 +15,7 @@ import (
 type SocketMetadata struct {
 	Family int
 	Type   int
+	Protocol int
 }
 
 // Tracer is not thread-safe.


### PR DESCRIPTION
1. Fix ICMP forwarding problem
2. Add mapper of fake IP to real IP
3. Save real IP every time a request is sent, and restore real IP every time it is not TCP and UDP