### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Write a config variable with `-w`:
 Set subscription:
 
 ```bash
-gg config -w subscription=https://example.com/path/to/sub
+gg config -w subscription=‘https://example.com/path/to/sub’
 gg curl ipv4.appspot.com
 ```
 


### PR DESCRIPTION
gg config -w 写入的订阅，如果订阅的https链接里面带个“?”  会让shell 截断命令，写入的订阅地址不完整，无法使用订阅。

加个单引号避免这个问题。