### PR TITLE
Fix Trojan-go WebSocket path configuration

### DIFF
--- a/dialer/trojan/trojan.go
+++ b/dialer/trojan/trojan.go
@@ -81,9 +81,9 @@ func (s *Trojan) Dialer() (*dialer.Dialer, error) {
 		u = url.URL{
 			Scheme: "ws",
 			Host:   net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
+			Path:   s.Path,
 			RawQuery: url.Values{
 				"host":          []string{s.Host},
-				"path":          []string{s.Path},
 				"allowInsecure": []string{common.BoolToString(s.AllowInsecure)},
 			}.Encode(),
 		}


### PR DESCRIPTION
## Issue

WebSocket path was misconfigured as a query parameter, causing 404 errors.

## Fix

Set path in URL directly and drop redundant query param.