### PR TITLE
ci: update release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Get the version
@@ -67,7 +67,7 @@ jobs:
             commit=$(git rev-parse --short HEAD)
             version="test-$date.r${count}.$commit"
           fi
-          echo ::set-output name=VERSION::"$version"
+          echo "VERSION=$version" >> "$GITHUB_OUTPUT"
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Show workflow information
@@ -75,12 +75,11 @@ jobs:
         run: |
           export _NAME=$(jq ".[\"$GOOS-$GOARCH$GOARM\"].friendlyName" -r < release/friendly-filenames.json)
           echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME: $_NAME"
-          echo "::set-output name=ASSET_NAME::$_NAME"
+          echo "ASSET_NAME=$_NAME" >> "$GITHUB_OUTPUT"
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          stable: true
           go-version: '1.18'
 
       - name: Get project dependencies
@@ -104,7 +103,7 @@ jobs:
           openssl dgst -sha256 $FILE | sed 's/([^)]*)//g' >>$DGST
           openssl dgst -sha512 $FILE | sed 's/([^)]*)//g' >>$DGST
       - name: Upload files to Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: gg-${{ steps.get_filename.outputs.ASSET_NAME }}
           path: gg-${{ steps.get_filename.outputs.ASSET_NAME }}


### PR DESCRIPTION
## Why

The release workflow is still using legacy GitHub Actions template versions. In particular, the artifact upload step uses `actions/upload-artifact@v2`, which GitHub has deprecated for current workflow runs. This causes CI/release jobs to fail before artifacts can be uploaded.

## What This PR Fixes

- Replaces `actions/upload-artifact@v2` with `actions/upload-artifact@v4` so release artifacts can be uploaded with the supported artifact action.
- Updates official setup actions from old v2 templates to maintained major versions:
  - `actions/checkout@v2` -> `actions/checkout@v7`
  - `actions/setup-go@v2` -> `actions/setup-go@v6`
- Replaces deprecated `::set-output` workflow commands with `$GITHUB_OUTPUT`, preserving the existing `VERSION` and `ASSET_NAME` outputs used by later build/upload steps.
- Keeps the existing release matrix, artifact names, build flags, smoke test, and GitHub release upload behavior unchanged.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v -o /tmp/gg-ci-check -trimpath -ldflags "-X github.com/mzz2017/gg/cmd.Version=ci-check -s -w -buildid=" .`

Note: `go test ./...` on local macOS is not a valid full check for this project because Linux-specific ptrace/capability packages fail to compile on darwin. Cross-target `GOOS=linux go test ./...` compiles packages but cannot execute Linux test binaries on macOS, producing expected `exec format error` for packages with tests. The workflow itself builds Linux targets on GitHub-hosted Linux runners.